### PR TITLE
Fix Bloop 1.4.1 install

### DIFF
--- a/bloop.json
+++ b/bloop.json
@@ -3,14 +3,11 @@
   "url": "https://github.com/scalacenter/bloop/releases/download/v1.4.1/bloop-coursier.json",
   "hash": "sha256:2e6a873183e5e22712913bfdab1331d0a7792167c369fee5be0c83e27572fe12",
   "depends": "coursier",
-  "bin": "bloop",
-  "env_add_path": "$dir",
+  "bin": "bloop.bat",
   "env_set": {
-    "BLOOP_HOME": "$dir",
-    "BLOOP_IN_SCOOP": "true"
+    "BLOOP_HOME": "$dir"
   },
   "installer": {
-    "script": "coursier install --install-dir $dir --default-channels=false --channel $dir bloop"
+    "script": "coursier install --install-dir $dir bloop"
   }
 }
-        


### PR DESCRIPTION
Fixes Bloop install on Windows - Coursier channel use wasn't working for some reason.

No longer adds BLOOP_IN_SCOOP variable (was used for Python install)
No longer adds Bloop to path (I don't think this is needed as Scoop's shims are on path)
Creates a shim to `bloop.bat` instead of to `bloop` which didn't exist
